### PR TITLE
Add Node 14 and other minor updates to GitHub CI configs

### DIFF
--- a/.github/workflows/boilerplate.yml
+++ b/.github/workflows/boilerplate.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - name: Checkout
@@ -27,7 +27,7 @@ jobs:
     - name: Build
       run: yarn build
     - name: Post Coverage
-      uses: codecov/codecov-action@v1.0.10
+      uses: codecov/codecov-action@v1.0.11
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
 
     defaults:

--- a/.github/workflows/boilerplate.yml
+++ b/.github/workflows/boilerplate.yml
@@ -3,32 +3,31 @@ name: boilerplate
 on: [push]
 
 jobs:
-  # react-redux-typescript-sass-boilerplates/boilerplate
+  # react-redux-typescript-sass-boilerplate/boilerplate
   boilerplate:
-    runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 12.x, 14.x]
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2.3.1
-    - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2.1.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        check-latest: true
-    - name: Install Dependencies
-      run: yarn install
-    - name: Run Tests
-      run: yarn test
-    - name: Build
-      run: yarn build
-    - name: Post Coverage
-      uses: codecov/codecov-action@v1.0.11
-      if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.1.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
+      - name: Install Dependencies
+        run: yarn install
+      - name: Run Tests
+        run: yarn test
+      - name: Build
+        run: yarn build
+      - name: Post Coverage
+        uses: codecov/codecov-action@v1.0.11
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
 
     defaults:
       run:

--- a/.github/workflows/boilerplate.yml
+++ b/.github/workflows/boilerplate.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 12.x, 14.x]
+
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -3,32 +3,32 @@ name: demos
 on: [push]
 
 jobs:
-  # react-redux-typescript-sass-boilerplates/demo
+  # react-redux-typescript-sass-boilerplate/demo
   demo:
-    runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 12.x, 14.x]
 
+    runs-on: ${{ matrix.os }}
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2.3.1
-    - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2.1.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        check-latest: true
-    - name: Install Dependencies
-      run: yarn install
-    - name: Run Tests
-      run: yarn test
-    - name: Build
-      run: yarn build
-    - name: Post Coverage
-      uses: codecov/codecov-action@v1.0.11
-      if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.1.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
+      - name: Install Dependencies
+        run: yarn install
+      - name: Run Tests
+        run: yarn test
+      - name: Build
+        run: yarn build
+      - name: Post Coverage
+        uses: codecov/codecov-action@v1.0.11
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
 
     defaults:
       run:
@@ -38,32 +38,32 @@ jobs:
     env:
       CI: true
 
-  # react-redux-typescript-sass-boilerplates/demo-container-pattern
+  # react-redux-typescript-sass-boilerplate/demo-container-pattern
   demo-container:
-    runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 12.x, 14.x]
 
+    runs-on: ${{ matrix.os }}
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2.3.1
-    - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2.1.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        check-latest: true
-    - name: Install Dependencies
-      run: yarn install
-    - name: Run Tests
-      run: yarn test
-    - name: Build
-      run: yarn build
-    - name: Post Coverage
-      uses: codecov/codecov-action@v1.0.11
-      if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.1.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
+      - name: Install Dependencies
+        run: yarn install
+      - name: Run Tests
+        run: yarn test
+      - name: Build
+        run: yarn build
+      - name: Post Coverage
+        uses: codecov/codecov-action@v1.0.11
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
 
     defaults:
       run:

--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - name: Checkout
@@ -27,7 +27,7 @@ jobs:
     - name: Build
       run: yarn build
     - name: Post Coverage
-      uses: codecov/codecov-action@v1.0.10
+      uses: codecov/codecov-action@v1.0.11
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
 
     defaults:
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - name: Checkout
@@ -62,7 +62,7 @@ jobs:
     - name: Build
       run: yarn build
     - name: Post Coverage
-      uses: codecov/codecov-action@v1.0.10
+      uses: codecov/codecov-action@v1.0.11
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
 
     defaults:


### PR DESCRIPTION
1. Add Node 14.x to all.
2. Update Codecov to 1.0.11.
3. Run through formatter.