### PR TITLE
Allow auto port assignment for webpack-dev-server

### DIFF
--- a/demo-container-pattern/webpack.dev.js
+++ b/demo-container-pattern/webpack.dev.js
@@ -7,8 +7,6 @@ const paths = require("./webpack.common.js").paths;
 const common = require("./webpack.common.js").config;
 
 module.exports = merge(common, {
-  // "development" will enable debug and etc.
-  // "production" will enable minifier and etc.
   mode: "development",
 
   // "source-map" for "production"
@@ -17,10 +15,11 @@ module.exports = merge(common, {
 
   devServer: {
     host: "0.0.0.0", // 0.0.0.0 to allow external devices to access
-    port: 3000,
-    public: "localhost:3000", // The specified url will be opened automatically on every run (if `open` is true)
+    // port: 3000, // Commented to allow dynamic ports for multiple instances
+    // public: `localhost:3000`, // The specified url will be opened automatically on every run (if `open` is true)
     hot: true, // Hot Module Replacement (HMR) allows modules to be updated at runtime without a full refresh
     open: true,
+    useLocalIp: true, // Open ip:port instead of 0.0.0.0:port (Windows does not recognize 0.0.0.0)
   },
 
   plugins: [
@@ -33,9 +32,9 @@ module.exports = merge(common, {
 
     // Analyze project structure and size of each chunk
     new BundleAnalyzerPlugin({
-      analyzerMode: "server", // Start a HTTP server to show bundle report
-      analyzerHost: "127.0.0.1", // http://localhost
-      analyzerPort: 8888, // http://localhost:8888
+      analyzerMode: "server", // Start a HTTP server to show the bundle report
+      analyzerHost: "127.0.0.1", // a.k.a. http://localhost
+      analyzerPort: "auto", // Auto to allow dynamic ports for multiple instances
       openAnalyzer: true, // Open automatically on every run
     }),
   ],

--- a/demo/webpack.dev.js
+++ b/demo/webpack.dev.js
@@ -7,8 +7,6 @@ const paths = require("./webpack.common.js").paths;
 const common = require("./webpack.common.js").config;
 
 module.exports = merge(common, {
-  // "development" will enable debug and etc.
-  // "production" will enable minifier and etc.
   mode: "development",
 
   // "source-map" for "production"
@@ -17,10 +15,11 @@ module.exports = merge(common, {
 
   devServer: {
     host: "0.0.0.0", // 0.0.0.0 to allow external devices to access
-    port: 3000,
-    public: "localhost:3000", // The specified url will be opened automatically on every run (if `open` is true)
+    // port: "3000", // Commented to allow dynamic ports for multiple instances
+    // public: `localhost:3000`, // The specified url will be opened automatically on every run (if `open` is true)
     hot: true, // Hot Module Replacement (HMR) allows modules to be updated at runtime without a full refresh
     open: true,
+    useLocalIp: true, // Open ip:port instead of 0.0.0.0:port (Windows does not recognize 0.0.0.0)
   },
 
   plugins: [
@@ -33,9 +32,9 @@ module.exports = merge(common, {
 
     // Analyze project structure and size of each chunk
     new BundleAnalyzerPlugin({
-      analyzerMode: "server", // Start a HTTP server to show bundle report
-      analyzerHost: "127.0.0.1", // http://localhost
-      analyzerPort: 8888, // http://localhost:8888
+      analyzerMode: "server", // Start a HTTP server to show the bundle report
+      analyzerHost: "127.0.0.1", // a.k.a. http://localhost
+      analyzerPort: "auto", // Auto to allow dynamic ports for multiple instances
       openAnalyzer: true, // Open automatically on every run
     }),
   ],


### PR DESCRIPTION
Allow auto port assignment for `webpack-dev-server` and `webpack-bundle-analyzer`.