### PR TITLE
Set Yarn network timeout

### DIFF
--- a/boilerplate/.yarnrc
+++ b/boilerplate/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000

--- a/demo-container-pattern/.yarnrc
+++ b/demo-container-pattern/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000

--- a/demo/.yarnrc
+++ b/demo/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000


### PR DESCRIPTION
Set `network-timeout 600000` in `.yarnrc` to fix the inconsistent default network timeout issue when on different OS or Node.