### PR TITLE
Add predeploy and deploy scripts

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -10,6 +10,8 @@
     "prebuild": "npm run lint",
     "build": "webpack --config webpack.prod.js",
     "build-dev": "webpack --config webpack.dev.js",
+    "predeploy": "npm run build",
+    "deploy": "",
     "watch": "webpack --watch",
     "test": "jest --coverage",
     "test-watch": "npm test -- --watch",

--- a/demo-container-pattern/package.json
+++ b/demo-container-pattern/package.json
@@ -10,6 +10,8 @@
     "prebuild": "npm run lint",
     "build": "webpack --config webpack.prod.js",
     "build-dev": "webpack --config webpack.dev.js",
+    "predeploy": "npm run build",
+    "deploy": "netlify deploy",
     "watch": "webpack --watch",
     "test": "jest --coverage",
     "test-watch": "npm test -- --watch",

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,6 +10,8 @@
     "prebuild": "npm run lint",
     "build": "webpack --config webpack.prod.js",
     "build-dev": "webpack --config webpack.dev.js",
+    "predeploy": "npm run build",
+    "deploy": "netlify deploy",
     "watch": "webpack --watch",
     "test": "jest --coverage",
     "test-watch": "npm test -- --watch",


### PR DESCRIPTION
Add the missing `predeploy` and `deploy` scripts for all `package.json`. For `boilerplate`, the `deploy` script is kept empty.